### PR TITLE
Fixed crash that could occur when only resizing the Sub Band Size

### DIFF
--- a/Source/AudioAnalysisTools/Private/Analyzers/BeatDetection.cpp
+++ b/Source/AudioAnalysisTools/Private/Analyzers/BeatDetection.cpp
@@ -27,7 +27,7 @@ void UBeatDetection::UpdateFFTSubbandsSize(int32 InFFTSubbandsSize)
 	if (InFFTSubbandsSize <= 0)
 	{
 		// Tell the user that they've tried to use an incorrect value, and where they tried it
-		UE_LOG(LogAudioAnalysis, Log, TEXT("Beat Detection FFT subbands size '%d' is invalid"), InFFTSubbandsSize);
+		UE_LOG(LogAudioAnalysis, Log, TEXT("Beat Detection FFT subbands size '%d' is invalid, value '%d' remains"), InFFTSubbandsSize, FFTSubbandsSize);
 		return;
 	}
 
@@ -51,7 +51,7 @@ void UBeatDetection::UpdateEnergyHistorySize(int32 InEnergyHistorySize)
 	if (InEnergyHistorySize <= 0)
 	{
 		// Tell the user that they've tried to use an incorrect value, and where they tried it
-		UE_LOG(LogAudioAnalysis, Log, TEXT("Beat Detection energy history size '%d' is invalid, using default of 41"), InEnergyHistorySize);
+		UE_LOG(LogAudioAnalysis, Log, TEXT("Beat Detection energy history size '%d' is invalid, value '%d' remains"), InEnergyHistorySize, EnergyHistorySize);
 		return;
 	}
 

--- a/Source/AudioAnalysisTools/Private/Analyzers/BeatDetection.cpp
+++ b/Source/AudioAnalysisTools/Private/Analyzers/BeatDetection.cpp
@@ -24,12 +24,11 @@ UBeatDetection* UBeatDetection::CreateBeatDetection(int32 InFFTSubbandsSize, int
 void UBeatDetection::UpdateFFTSubbandsSize(int32 InFFTSubbandsSize)
 {
 	// We'll assume nothing, and make sure our user has made a reasonable request
-	if(InFFTSubbandsSize <= 0)
+	if (InFFTSubbandsSize <= 0)
 	{
 		// Tell the user that they've tried to use an incorrect value, and where they tried it
-		UE_LOG(LogAudioAnalysis, Log, TEXT("Beat Detection FFT subbands size '%d' is invalid, using default of 32"), InFFTSubbandsSize);
-		// Correct their mistake, and move on
-		InFFTSubbandsSize = 32;
+		UE_LOG(LogAudioAnalysis, Log, TEXT("Beat Detection FFT subbands size '%d' is invalid"), InFFTSubbandsSize);
+		return;
 	}
 
 	UE_LOG(LogAudioAnalysis, Log, TEXT("Updating Beat Detection FFT subbands size from '%d' to '%d'"), FFTSubbandsSize, InFFTSubbandsSize);
@@ -53,8 +52,7 @@ void UBeatDetection::UpdateEnergyHistorySize(int32 InEnergyHistorySize)
 	{
 		// Tell the user that they've tried to use an incorrect value, and where they tried it
 		UE_LOG(LogAudioAnalysis, Log, TEXT("Beat Detection energy history size '%d' is invalid, using default of 41"), InEnergyHistorySize);
-		// Correct their mistake, and move on
-		InEnergyHistorySize = 41;
+		return;
 	}
 
 	UE_LOG(LogAudioAnalysis, Log, TEXT("Updating Beat Detection energy history size from '%d' to '%d'"), EnergyHistorySize, InEnergyHistorySize);
@@ -126,6 +124,12 @@ void UBeatDetection::ProcessMagnitude(const TArray<float>& MagnitudeSpectrum)
 
 bool UBeatDetection::IsBeat(int32 SubBand) const
 {
+	// Prevent out of array exception
+	if (SubBand >= FFTSubbandsSize)
+	{
+		UE_LOG(LogAudioAnalysis, Error, TEXT("Cannot check if beat: sub band ('%d') must not be greater than sub bands size ('%d')"), SubBand, FFTSubbandsSize);
+		return false;
+	}
 	return FFTSubbands[SubBand] > FFTAverageEnergy[SubBand] * FFTBeatValues[SubBand];
 }
 

--- a/Source/AudioAnalysisTools/Private/Analyzers/BeatDetection.cpp
+++ b/Source/AudioAnalysisTools/Private/Analyzers/BeatDetection.cpp
@@ -16,7 +16,7 @@ UBeatDetection* UBeatDetection::CreateBeatDetection(int32 InFFTSubbandsSize, int
 	UBeatDetection* BeatDetection{NewObject<UBeatDetection>()};
 	
 	// We'll set this here, so we only resize the energy history arrays once, in the UpdateFFTSubbandsSize function
-	EnergyHistorySize = InEnergyHistorySize;
+	BeatDetection->EnergyHistorySize = InEnergyHistorySize;
 	BeatDetection->UpdateFFTSubbandsSize(InFFTSubbandsSize);
 	return BeatDetection;
 }

--- a/Source/AudioAnalysisTools/Private/Analyzers/BeatDetection.cpp
+++ b/Source/AudioAnalysisTools/Private/Analyzers/BeatDetection.cpp
@@ -14,13 +14,24 @@ UBeatDetection::UBeatDetection()
 UBeatDetection* UBeatDetection::CreateBeatDetection(int32 InFFTSubbandsSize, int32 InEnergyHistorySize)
 {
 	UBeatDetection* BeatDetection{NewObject<UBeatDetection>()};
+	
+	// We'll set this here, so we only resize the energy history arrays once, in the UpdateFFTSubbandsSize function
+	EnergyHistorySize = InEnergyHistorySize;
 	BeatDetection->UpdateFFTSubbandsSize(InFFTSubbandsSize);
-	BeatDetection->UpdateEnergyHistorySize(InEnergyHistorySize);
 	return BeatDetection;
 }
 
 void UBeatDetection::UpdateFFTSubbandsSize(int32 InFFTSubbandsSize)
 {
+	// We'll assume nothing, and make sure our user has made a reasonable request
+	if(InFFTSubbandsSize <= 0)
+	{
+		// Tell the user that they've tried to use an incorrect value, and where they tried it
+		UE_LOG(LogAudioAnalysis, Log, TEXT("Beat Detection FFT subbands size '%d' is invalid, using default of 32"), InFFTSubbandsSize);
+		// Correct their mistake, and move on
+		InFFTSubbandsSize = 32;
+	}
+
 	UE_LOG(LogAudioAnalysis, Log, TEXT("Updating Beat Detection FFT subbands size from '%d' to '%d'"), FFTSubbandsSize, InFFTSubbandsSize);
 	
 	FFTSubbandsSize = InFFTSubbandsSize;
@@ -30,10 +41,22 @@ void UBeatDetection::UpdateFFTSubbandsSize(int32 InFFTSubbandsSize)
 	FFTVariance.SetNum(FFTSubbandsSize);
 	FFTBeatValues.SetNum(FFTSubbandsSize);
 	EnergyHistory.SetNum(FFTSubbandsSize);
+
+	// We resized the external array, so we have to resize the new array
+	UpdateEnergyHistorySize(EnergyHistorySize);
 }
 
 void UBeatDetection::UpdateEnergyHistorySize(int32 InEnergyHistorySize)
 {
+	// We'll assume nothing, and make sure our user has made a reasonable request
+	if (InEnergyHistorySize <= 0)
+	{
+		// Tell the user that they've tried to use an incorrect value, and where they tried it
+		UE_LOG(LogAudioAnalysis, Log, TEXT("Beat Detection energy history size '%d' is invalid, using default of 41"), InEnergyHistorySize);
+		// Correct their mistake, and move on
+		InEnergyHistorySize = 41;
+	}
+
 	UE_LOG(LogAudioAnalysis, Log, TEXT("Updating Beat Detection energy history size from '%d' to '%d'"), EnergyHistorySize, InEnergyHistorySize);
 	
 	EnergyHistorySize = InEnergyHistorySize;


### PR DESCRIPTION
Also added in checks for resizing the `FFTSubbandsSize` and `EnergyHistorySize`, removed a call to the `UpdateEnergyHistorySize` in the `CreateBeatDetection` function, replaced with updating the `EnergyHistorySize` directly; we immediately call a function that calls the `UpdateEnergyHistorySize`